### PR TITLE
Initial release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+node_modules
+package-lock.json
+
+# Visual Studio Code ignoramuses.
+.vscode/
+
+# IDE Code ignoramuses.
+.idea/
+
+# Various Windows ignoramuses.
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+*.cab
+*.msi
+*.msm
+*.msp
+*.lnk
+
+# Various OSX ignoramuses.
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Various Linux ignoramuses.
+
+.fuse_hidden*
+.directory
+.Trash-*

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Michael Schmidt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Module: mmm-energy-saver
 
-The `mmm-energy-saver` module is a [MagicMirror](https://github.com/MichMich/MagicMirror) addon.
+The `mmm-energy-saver` module is a [MagicMirror](https://github.com/MichMich/MagicMirror) addon.<br/>
 This module requires MagicMirror version `2.5` or later.
 
-This module works in conjunction with [MMM-Pir-Sensor](https://github.com/paviro/MMM-PIR-Sensor) to automatically suspend & resume all your modules based on movement detection. Furthermore, this module allows you to specify times when all the modules are suspended and the screen is turned off as well.
+This module works in conjunction with [MMM-Pir-Sensor](https://github.com/paviro/MMM-PIR-Sensor) to automatically suspend & resume all your modules based on movement detection. Furthermore, this module allows you to specify times when all the modules are suspended and your HDMI-connected screen is turned off as well.
 
 **Please note that the movement detection will not work unless you have the MMM-Pir-Sensor module installed (and working).**
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ By design, this module has fairly limited functionality - which is nice because 
 - [Installing the module](#installing-the-module)
 - [Using the module](#using-the-module)
 - [General Configuration Options](#general-configuration-options)
+- [Cron Expressions](#cron-expressions)
 - [Developer Notes](#developer-notes)
 
 
@@ -41,13 +42,18 @@ Seeing that nothing is displayed on screen, there's no need to add a `position` 
 
 ## General Configuration Options
 
-Option             | Type      | Default         | Description
--------------------|-----------|-----------------|-------------------------------------------------------
-`timeoutInSeconds` | `int`     | `300`           | When motion is triggered, how long to wait before going to sleep. Default is 5 minutes.
-`triggerMonitor`   | `boolean` | `true`          | Whether the monitor should be turned on and off.
-`monitorOn`        | `string`  | `00 30 7 * * *` | When to turn the monitor on. Default is 7:30 am. Should be a valid [cron expression](https://github.com/kelektiv/node-cron#available-cron-patterns).
-`monitorOff`       | `string`  | `00 30 23 * * *`| When to turn the monitor off. Default is 11:30 pm. Should be a valid [cron expression](https://github.com/kelektiv/node-cron#available-cron-patterns).
+Option             | Type      | Default          | Description
+-------------------|-----------|------------------|-------------------------------------------------------
+`timeoutInSeconds` | `int`     | `300`            | When motion is triggered, how long to wait before going to sleep. Default is 5 minutes.
+`triggerMonitor`   | `boolean` | `true`           | Whether the monitor should be turned on and off.
+`monitorOn`        | `string`  | `00 30 7 * * *`  | When to turn the monitor on. Default is 7:30 am.
+`monitorOff`       | `string`  | `00 30 23 * * *` | When to turn the monitor off. Default is 11:30 pm.
 
+
+## Cron Expressions
+
+Both the `monitorOn` and `monitorOff` settings take valid `cron` expressions as their arguments. If you're confused as to the syntax to use,
+check out the [Node-Cron documentation](https://github.com/kelektiv/node-cron#available-cron-patterns).
 
 
 ## Developer Notes

--- a/README.md
+++ b/README.md
@@ -1,1 +1,77 @@
-# mmm-energy-saver
+# Module: mmm-energy-saver
+
+The `mmm-energy-saver` module is a [MagicMirror](https://github.com/MichMich/MagicMirror) addon.
+This module requires MagicMirror version `2.5` or later.
+
+This module works in conjunction with [MMM-Pir-Sensor](https://github.com/paviro/MMM-PIR-Sensor) to automatically suspend & resume all your modules based on movement detection. Furthermore, this module allows you to specify times when all the modules are suspended and the screen is turned off as well.
+
+**Please note that the movement detection will not work unless you have the MMM-Pir-Sensor module installed (and working).**
+
+By design, this module has fairly limited functionality - which is nice because it makes it very easy to set up & use. If you, however, want a lot more control over the individual modules including setting specific timers based on days or showing alerts, I'd recommend checking out the [MMM-ModuleScheduler](https://github.com/ianperrin/MMM-ModuleScheduler) module instead.
+
+
+## Table of Contents
+
+- [Installing the module](#installing-the-module)
+- [Using the module](#using-the-module)
+- [General Configuration Options](#general-configuration-options)
+- [Developer Notes](#developer-notes)
+
+
+## Installing the module
+
+1) Run `git clone https://github.com/michael5r/mmm-energy-saver.git` from inside your `MagicMirror/modules` folder.
+2) Run `cd mmm-energy-saver` in the same terminal window, then `npm install` to install the required Node modules.
+
+
+## Using the module
+To use this module, simply add it to the `modules` array in the MagicMirror `config/config.js` file:
+
+```js
+{
+    module: "mmm-energy-saver",
+    config: {
+        // ... whatever configuration options you want to use
+    }
+},
+```
+
+Seeing that nothing is displayed on screen, there's no need to add a `position` property.
+
+
+## General Configuration Options
+
+Option             | Type      | Default         | Description
+-------------------|-----------|-----------------|-------------------------------------------------------
+`timeoutInSeconds` | `int`     | `300`           | When motion is triggered, how long to wait before going to sleep. Default is 5 minutes.
+`triggerMonitor`   | `boolean` | `true`          | Whether the monitor should be turned on and off.
+`monitorOn`        | `string`  | `00 30 7 * * *` | When to turn the monitor on. Default is 7:30 am. Should be a valid [cron expression](https://github.com/kelektiv/node-cron#available-cron-patterns).
+`monitorOff`       | `string`  | `00 30 23 * * *`| When to turn the monitor off. Default is 11:30 pm. Should be a valid [cron expression](https://github.com/kelektiv/node-cron#available-cron-patterns).
+
+
+
+## Developer Notes
+
+There are two ways of using this module's functionality inside other modules:
+
+1) This module broadcasts a `MMM_ENERGY_SAVER` notification with the payload being either `suspend` or `resume` - you can listen for this notification in the `notificationReceived` method inside your own module and have your module update accordingly.
+
+2) Seeing that this module uses the standard MagicMirror `module.hide` and `module.show` functions to hide/show modules which, in turn, automatically trigger the `suspend` & `resume` methods, it's fairly trivial to extend these directly in your module - like this:
+
+```js
+suspend: function() {
+    // this method is triggered when a module is hidden using this.hide()
+    // do something inside this module
+},
+
+resume: function() {
+    // this method is triggered when a module is shown using this.show()
+    // do something inside this module
+},
+```
+
+I personally prefer method `2` - it's very clean and allows you to easily do stuff like temporarily pausing data updating when a module is suspended (aka hidden on the screen).
+
+For more info, check out the MagicMirror [Modules](https://github.com/MichMich/MagicMirror/tree/master/modules#suspend) documentation.
+
+For an example of how method `2` works, check out my [mmm-nest-status](https://github.com/michael5r/mmm-nest-status) module.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Seeing that nothing is displayed on screen, there's no need to add a `position` 
 
 Option             | Type      | Default          | Description
 -------------------|-----------|------------------|-------------------------------------------------------
-`timeoutInSeconds` | `int`     | `300`            | When motion is triggered, how long to wait before going to sleep. Default is 5 minutes.
+`timeoutInSeconds` | `int`     | `300`            | When motion is triggered, how long to wait before going to sleep.<br>Default is 5 minutes.
 `triggerMonitor`   | `boolean` | `true`           | Whether the monitor should be turned on and off.
 `monitorOn`        | `string`  | `00 30 7 * * *`  | When to turn the monitor on. Default is 7:30 am.
 `monitorOff`       | `string`  | `00 30 23 * * *` | When to turn the monitor off. Default is 11:30 pm.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Seeing that nothing is displayed on screen, there's no need to add a `position` 
 
 Option             | Type      | Default          | Description
 -------------------|-----------|------------------|-------------------------------------------------------
-`timeoutInSeconds` | `int`     | `300`            | When motion is triggered, how long to wait<br>before going to sleep. Default is 5 minutes.
+`timeoutInSeconds` | `int`     | `300`            | When motion is triggered, how long to wait<br/>before going to sleep. Default is 5 minutes.
 `triggerMonitor`   | `boolean` | `true`           | Whether the monitor should be turned on and off.
 `monitorOn`        | `string`  | `00 30 7 * * *`  | When to turn the monitor on. Default is 7:30 am.
 `monitorOff`       | `string`  | `00 30 23 * * *` | When to turn the monitor off. Default is 11:30 pm.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Seeing that nothing is displayed on screen, there's no need to add a `position` 
 
 Option             | Type      | Default          | Description
 -------------------|-----------|------------------|-------------------------------------------------------
-`timeoutInSeconds` | `int`     | `300`            | When motion is triggered, how long to wait before going to sleep.<br>Default is 5 minutes.
+`timeoutInSeconds` | `int`     | `300`            | When motion is triggered, how long to wait<br>before going to sleep. Default is 5 minutes.
 `triggerMonitor`   | `boolean` | `true`           | Whether the monitor should be turned on and off.
 `monitorOn`        | `string`  | `00 30 7 * * *`  | When to turn the monitor on. Default is 7:30 am.
 `monitorOff`       | `string`  | `00 30 23 * * *` | When to turn the monitor off. Default is 11:30 pm.

--- a/mmm-energy-saver.js
+++ b/mmm-energy-saver.js
@@ -1,0 +1,127 @@
+/* global Module */
+
+/* Magic Mirror
+ * Module: mmm-energy-saver
+ *
+ * By Michael Schmidt
+ * https://github.com/michael5r
+ *
+ * MIT Licensed.
+ */
+
+Module.register('mmm-energy-saver', {
+
+    defaults: {
+        timeoutInSeconds: 300,        // this is in seconds (not ms)
+        triggerMonitor: true,         // whether the monitor should be turned off
+        monitorOn: '00 30 7 * * *',   // on at 07:30 am
+        monitorOff: '00 30 23 * * *', // off at 11:30 pm
+        animationSpeed: 2 * 1000,
+        version: '1.0.0'
+    },
+
+    start: function() {
+
+        Log.info('Starting module: ' + this.name + ', version ' + this.config.version);
+
+        this.sendSocketNotification('MMM_ENERGY_SAVER_CONFIG', this.config);
+
+        this.sleepTimer = null;
+        this.sleeping = false;
+        this.deepSleep = false; // when the monitor is off
+
+    },
+
+    notificationReceived(notification, payload, sender) {
+
+        var self = this;
+
+        if (notification === 'DOM_OBJECTS_CREATED') {
+
+            this.sendSocketNotification('MMM_ENERGY_SAVER_INIT', true);
+
+        } else if (notification === 'USER_PRESENCE') {
+
+            if ((payload === true) && (!this.deepSleep)) {
+                if (this.sleeping) {
+                    this.sendResume();
+                } else {
+                    clearTimeout(this.sleepTimer);
+                    this.sleepTimer = setTimeout(function() {
+                        self.sendSuspend();
+                    }, self.config.timeoutInSeconds * 1000);
+                }
+            }
+
+        }
+
+    },
+
+    socketNotificationReceived: function(notification, payload) {
+
+        var self = this;
+
+        if (notification === 'MMM_ENERGY_SAVER_MONITOR_OFF') {
+
+            this.deepSleep = true;
+            clearTimeout(this.sleepTimer);
+            this.sendSuspend();
+
+        } else if (notification === 'MMM_ENERGY_SAVER_MONITOR_ON') {
+
+            this.deepSleep = false;
+            this.sendResume();
+
+            // restart regular timer
+            clearTimeout(this.sleepTimer);
+            this.sleepTimer = setTimeout(function() {
+                self.sendSuspend();
+            }, self.config.timeoutInSeconds * 1000);
+
+        }
+
+    },
+
+    sendSuspend: function() {
+
+        var self = this;
+
+        if (!this.sleeping) {
+
+            this.sleeping = true;
+
+            // hide all modules
+            MM.getModules().exceptModule(this).enumerate(function(module) {
+                module.hide(self.config.animationSpeed);
+            });
+
+            // send notification
+            console.log(self.name + ' has suspended all modules ...');
+            this.sendNotification('MMM_ENERGY_SAVER', 'suspend');
+
+        }
+
+    },
+
+    sendResume: function() {
+
+        var self = this;
+
+        if (this.sleeping) {
+
+            this.sleeping = false;
+
+            // show all modules
+            MM.getModules().exceptModule(this).enumerate(function(module) {
+                module.show(self.config.animationSpeed);
+            });
+
+            // send notification
+            console.log(self.name + ' has resumed all modules ...');
+            this.sendNotification('MMM_ENERGY_SAVER', 'resume');
+
+        }
+
+    }
+
+});

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,0 +1,102 @@
+var NodeHelper = require('node_helper');
+var exec = require('child_process').exec;
+var CronJob = require('cron').CronJob;
+
+module.exports = NodeHelper.create({
+
+    scheduledJobs: [],
+
+    start: function() {
+
+        console.log('Starting node_helper for module [' + this.name + ']');
+
+        this.started = false;
+        this.config = {};
+
+    },
+
+    initialize: function(config) {
+
+        // set up monitor cron job
+        if (this.config.triggerMonitor) {
+            this.createCronJobs();
+        }
+
+    },
+
+    turnOnMonitor: function() {
+
+        // check to see if HDMI output is already on
+        exec('/usr/bin/vcgencmd display_power').stdout.on('data', function(data) {
+            if (data.indexOf('display_power=0') > -1) {
+                // turn on HDMI output
+                exec('/usr/bin/vcgencmd display_power 1', null);
+            }
+        });
+
+        this.sendSocketNotification('MMM_ENERGY_SAVER_MONITOR_ON', true);
+
+    },
+
+    turnOffMonitor: function() {
+
+        // turn off HDMI output
+        exec('/usr/bin/vcgencmd display_power 0', null);
+
+        this.sendSocketNotification('MMM_ENERGY_SAVER_MONITOR_OFF', true);
+
+    },
+
+    createCronJobs: function() {
+
+        var self = this;
+
+        // check for old cron jobs
+        if (this.scheduledJobs.length > 0) {
+            for (var i = 0; i < this.scheduledJobs.length; i++) {
+                var job = this.scheduledJobs[i];
+                this.stopCronJob(job);
+            }
+            this.scheduledJobs = [];
+        }
+
+        // create the monitor off cron job
+        var offJob = new CronJob(self.config.monitorOff, function() {
+            self.turnOffMonitor();
+        });
+
+        self.scheduledJobs.push(offJob);
+
+        // create the monitor on cron job
+        var onJob = new CronJob(self.config.monitorOn, function() {
+            self.turnOnMonitor();
+        });
+
+        offJob.start();
+        onJob.start();
+
+        self.scheduledJobs.push(offJob);
+        self.scheduledJobs.push(onJob);
+
+    },
+
+    stopCronJob: function(cronJob) {
+        try {
+            cronJob.stop();
+        } catch(err) {
+            console.log(this.name + ' was unable to stop the cron job.');
+        }
+    },
+
+    socketNotificationReceived: function(notification, payload) {
+
+        if ((notification === 'MMM_ENERGY_SAVER_CONFIG') && (!this.started)) {
+            this.config = payload;
+            this.started = true;
+        } else if (notification === 'MMM_ENERGY_SAVER_INIT') {
+            this.initialize();
+        }
+
+    }
+
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "mmm-energy-saver",
+  "version": "1.0.0",
+  "description": "Energy saver module for MagicMirror",
+  "main": "mmm-energy-saver.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/michael5r/mmm-energy-saver.git"
+  },
+  "engines": {
+    "node": ">=8.9.0"
+  },
+  "author": "Michael Schmidt",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/michael5r/mmm-energy-saver/issues"
+  },
+  "homepage": "https://github.com/michael5r/mmm-energy-saver#readme",
+  "dependencies": {
+    "cron": "^1.6.0"
+  }
+}


### PR DESCRIPTION
The `mmm-energy-saver` module is a [MagicMirror](https://github.com/MichMich/MagicMirror) addon.<br/>
This module requires MagicMirror version `2.5` or later.

This module works in conjunction with [MMM-Pir-Sensor](https://github.com/paviro/MMM-PIR-Sensor) to automatically suspend & resume all your modules based on movement detection. Furthermore, this module allows you to specify times when all the modules are suspended and your HDMI-connected screen is turned off as well.